### PR TITLE
Remove cocoon gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ ruby IO.readlines(".ruby-version")[0].strip
 gem "bootsnap", ">= 1.1.0", require: false
 gem "bulma-extensions-rails"
 gem "bulma-rails", "~> 0.9.4"
-gem "cocoon"
 gem "devise"
 gem "font-awesome-rails"
 gem "haml-rails", "~> 2.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,7 +87,6 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     childprocess (4.1.0)
-    cocoon (1.2.15)
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
@@ -366,7 +365,6 @@ DEPENDENCIES
   bulma-extensions-rails
   bulma-rails (~> 0.9.4)
   capybara
-  cocoon
   devise
   factory_bot_rails
   ffaker

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,7 +14,6 @@
 //= require rails-ujs
 //= require activestorage
 //= require turbolinks
-//= require cocoon
 //= require trix
 //= require plugins/initializer
 //= require_directory .


### PR DESCRIPTION
It seems like, we have had this unneeded gem from the beginning

To be honest I wanted to install the [vanilla-nested](https://github.com/arielj/vanilla-nested) gem from a friend of mine
to replace this one, hahaha oh surprise!!

we just don't need any gem to do nesting
