### PR TITLE
Fix actioncable deprecation warning

### DIFF
--- a/app/assets/javascripts/cable.js
+++ b/app/assets/javascripts/cable.js
@@ -1,7 +1,7 @@
 // Action Cable provides the framework to deal with WebSockets in Rails.
 // You can generate new channels where WebSocket features live using the `rails generate channel` command.
 //
-//= require action_cable
+//= require actioncable
 //= require_self
 //= require_tree ./channels
 


### PR DESCRIPTION
DEPRECATION: action_cable.js has been renamed to actioncable.js – please update your reference before Rails 8