### PR TITLE
Add hospital relationship to patient

### DIFF
--- a/.standard_todo.yml
+++ b/.standard_todo.yml
@@ -1,6 +1,0 @@
-# Auto generated files with errors to ignore.
-# Remove from this list as you refactor files.
----
-ignore:
-- spec/models/patient_spec.rb:
-  - Lint/Void

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -55,19 +55,20 @@ class PatientsController < ApplicationController
   end
 
   def patient_params
-    params.require(:patient).permit(
-      :name, :first_name, :last_name, :birthday, :height,
-      :weight, :blood_group, :occupation, :referred_by,
-      :place_of_birth, :sex, :cellphone, :marital_status,
-      :comments, :avatar, :allergies, :pathological_background,
-      :non_pathological_background, :gyneco_obstetric_background,
-      :system_background, :family_inheritance_background,
-      :physic_exploration, :other_background,
-      address_attributes: [
-        :id, :street, :number, :colony, :postal_code, :municipality,
-        :state, :country, :_destroy
-      ]
-    )
+    params.require(:patient)
+      .permit(
+        :name, :first_name, :last_name, :birthday, :height,
+        :weight, :blood_group, :occupation, :referred_by,
+        :place_of_birth, :sex, :cellphone, :marital_status,
+        :comments, :avatar, :allergies, :pathological_background,
+        :non_pathological_background, :gyneco_obstetric_background,
+        :system_background, :family_inheritance_background,
+        :physic_exploration, :other_background,
+        address_attributes: [
+          :id, :street, :number, :colony, :postal_code, :municipality,
+          :state, :country, :_destroy
+        ]
+      ).with_defaults(hospital_id: current_user.hospital_id)
   end
 
   def pdf_name

--- a/app/models/doctor.rb
+++ b/app/models/doctor.rb
@@ -1,5 +1,4 @@
 class Doctor < User
-  belongs_to :hospital
   has_and_belongs_to_many :patients, join_table: "doctors_patients"
   has_many :appoinments
   has_many :hospitalizations, -> { order(created_at: :desc) }

--- a/app/models/hospital.rb
+++ b/app/models/hospital.rb
@@ -3,10 +3,10 @@ class Hospital < ApplicationRecord
 
   enum plan: {basic: 0, medium: 1}
 
-  has_one :address, as: :addressable, dependent: :destroy
   has_many :doctors, dependent: :destroy
   has_many :patient_referrals, dependent: :destroy
   has_many :patients, dependent: :destroy
+  has_one :address, as: :addressable, dependent: :destroy
 
   accepts_nested_attributes_for :address, allow_destroy: true
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,5 @@
 class User < ApplicationRecord
-  default_scope { where(hospital_id: Hospital.current_id) }
-
+  belongs_to :hospital
   enum role: {patient: 0, doctor: 1, admin: 2}
 
   validates :role, presence: true

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -17,6 +17,7 @@ FactoryBot.define do
     role { "patient" }
     type { "Patient" }
     confirmed_at { Time.zone.now }
+    association :hospital, factory: :hospital
 
     after :build do |patient|
       if patient.doctors.nil?

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -1,6 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Patient do
+  it { should belong_to :hospital }
   it { should have_one(:address).dependent(:destroy) }
   it { should have_and_belong_to_many :doctors }
   it { should have_many(:appoinments).dependent(:destroy) }

--- a/spec/requests/appoinments_spec.rb
+++ b/spec/requests/appoinments_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 RSpec.describe "appoinments", type: :request do
   let(:hospital) { create(:hospital, :basic) }
-  let(:doctor) { create(:doctor, hospital_id: hospital.id) }
+  let(:doctor) { create(:doctor, hospital: hospital) }
   let(:patient) do
-    create(:patient, doctors: [doctor], hospital_id: hospital.id)
+    create(:patient, doctors: [doctor], hospital: hospital)
   end
   let(:appoinment) do
     create(:appoinment, doctor: doctor, patient: patient)

--- a/spec/requests/hospitalizations_spec.rb
+++ b/spec/requests/hospitalizations_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 RSpec.describe "hospitalizations", type: :request do
   let(:hospital) { create(:hospital, :basic) }
-  let(:doctor) { create(:doctor, hospital_id: hospital.id) }
+  let(:doctor) { create(:doctor, hospital: hospital) }
   let(:patient) do
-    create(:patient, doctors: [doctor], hospital_id: hospital.id)
+    create(:patient, doctors: [doctor], hospital: hospital)
   end
   let(:referred_doctor) { create(:referred_doctor, doctor: doctor) }
   let(:hospitalization) do

--- a/spec/requests/patients_spec.rb
+++ b/spec/requests/patients_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 RSpec.describe "patients", type: :request do
   let(:hospital) { create(:hospital, :basic) }
-  let(:doctor) { create(:doctor, hospital_id: hospital.id) }
+  let(:doctor) { create(:doctor, hospital: hospital) }
   let(:patient) do
-    create(:patient, doctors: [doctor], hospital_id: hospital.id)
+    create(:patient, doctors: [doctor], hospital: hospital)
   end
 
   before do

--- a/spec/requests/referred_doctors_spec.rb
+++ b/spec/requests/referred_doctors_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "referred_doctors", type: :request do
       doctor: nil
     }
   end
-  let(:doctor) { create(:doctor, :admin, hospital_id: hospital.id) }
+  let(:doctor) { create(:doctor, :admin, hospital: hospital) }
 
   before do
     allow(Hospital).to receive(:current_id).and_return hospital.id

--- a/spec/support/feature/authentication_helpers.rb
+++ b/spec/support/feature/authentication_helpers.rb
@@ -11,7 +11,7 @@ module Feature
     end
 
     def sign_in_admin_doctor hospital
-      @admin = create(:doctor, hospital: hospital, role: "admin")
+      @admin = create(:doctor, hospital: hospital, role: :admin)
       visit new_user_session_path
       expect(page).to have_current_path(new_user_session_path)
 

--- a/spec/support/feature/subdomain_helpers.rb
+++ b/spec/support/feature/subdomain_helpers.rb
@@ -1,12 +1,12 @@
 module Feature
   module SubdomainHelpers
-    def set_capybara_subdomain
-      Capybara.app_host = "http://#{@hospital.subdomain}.lvh.me"
+    def capybara_subdomain(subdomain)
+      Capybara.app_host = "http://#{subdomain}.lvh.me"
     end
 
     def create_hospital_plan_medium
       @hospital = create(:hospital, :medium)
-      set_capybara_subdomain
+      capybara_subdomain(@hospital.subdomain)
     end
   end
 end

--- a/spec/system/appoinments_spec.rb
+++ b/spec/system/appoinments_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Medical Consultations flow", type: :system do
     scenario "creates an appoinment from the show page" do
       create_hospital_plan_medium
       sign_in_admin_doctor @hospital
-      @patient = create(:patient)
+      @patient = create(:patient, hospital: @hospital)
 
       visit patients_path
       expect(page).to have_content "Buscar"
@@ -29,8 +29,8 @@ RSpec.describe "Medical Consultations flow", type: :system do
       create_hospital_plan_medium
       sign_in_admin_doctor @hospital
 
-      @other_patient = create(:patient, name: "Zác", doctors: [@admin])
-      @patient = create(:patient, name: "Zac", doctors: [@admin])
+      @other_patient = create(:patient, name: "Zác", doctors: [@admin], hospital: @hospital)
+      @patient = create(:patient, name: "Zac", doctors: [@admin], hospital: @hospital)
 
       visit patients_path
       expect(page).to have_content "Buscar"
@@ -50,10 +50,10 @@ RSpec.describe "Medical Consultations flow", type: :system do
       end
     end
 
-    scenario "can action some pages", js: true do
+    scenario "can action some pages" do
       create_hospital_plan_medium
       sign_in_admin_doctor @hospital
-      patient = create(:patient, doctors: [@admin])
+      patient = create(:patient, doctors: [@admin], hospital: @hospital)
       appoinment = create(:appoinment, patient: patient, doctor: @admin)
 
       visit appoinments_path(appoinment)

--- a/spec/system/hospitalizations_spec.rb
+++ b/spec/system/hospitalizations_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Hospitalization's flow", type: :system do
     scenario "from patient list" do
       create_hospital_plan_medium
       sign_in_admin_doctor @hospital
-      @patient = create(:patient)
+      @patient = create(:patient, hospital: @hospital)
       @referred_doctor = create(:referred_doctor, doctor: @admin)
 
       visit patients_path


### PR DESCRIPTION
This is how it was managed under the default_scope

```ruby
rails console

Loading development environment (Rails 7.1.3.2)
irb(main):001>
irb(main):002> Doctor.count
  Doctor Count (0.6ms)  SELECT COUNT(*) FROM "users" WHERE "users"."type" = $1 AND "users"."hospital_id" IS NULL  [["type", "Doctor"]]
=> 0
irb(main):003> Patient.count
  Patient Count (0.6ms)  SELECT COUNT(*) FROM "users" WHERE "users"."type" = $1 AND "users"."hospital_id" IS NULL  [["type", "Patient"]]
=> 0
irb(main):004> Doctor.unscoped.count
  Doctor Count (0.3ms)  SELECT COUNT(*) FROM "users" WHERE "users"."type" = $1  [["type", "Doctor"]]
=> 4
irb(main):005> Patient.unscoped.count
  Patient Count (0.4ms)  SELECT COUNT(*) FROM "users" WHERE "users"."type" = $1  [["type", "Patient"]]
=> 40
irb(main):006>
```
And this is how it will behave from this change, we won't need to use the `unscoped` method to make the query return users, which is great
```ruby
rails console
Loading development environment (Rails 7.1.3.2)
irb(main):001> Doctor.count
  Doctor Count (1.0ms)  SELECT COUNT(*) FROM "users" WHERE "users"."type" = $1  [["type", "Doctor"]]
=> 4
irb(main):002> Patient.count
  Patient Count (0.5ms)  SELECT COUNT(*) FROM "users" WHERE "users"."type" = $1  [["type", "Patient"]]
=> 40
irb(main):004> Doctor.unscoped.count
  Doctor Count (0.8ms)  SELECT COUNT(*) FROM "users" WHERE "users"."type" = $1  [["type", "Doctor"]]
=> 4
irb(main):003> Patient.unscoped.count
  Patient Count (1.0ms)  SELECT COUNT(*) FROM "users" WHERE "users"."type" = $1  [["type", "Patient"]]
=> 40
irb(main):005>
```