### PR TITLE
Update select field options

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,7 +10,7 @@ module ApplicationHelper
       current_hospital
         .patients
         .order(name: :asc, first_name: :asc, last_name: :asc)
-        .map { |p| [p.to_s, p.id] }
+        .map { |u| [u.to_s, u.id] }
   end
 
   def referred_doctor_for_select
@@ -18,7 +18,7 @@ module ApplicationHelper
       ReferredDoctor
         .by_doctor(current_user.id)
         .order(full_name: :asc)
-        .map { |p| [p.to_s, p.id] }
+        .map { |u| [u.to_s, u.id] }
   end
 
   def states_for_select

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,7 +10,7 @@ module ApplicationHelper
       current_hospital
         .patients
         .order(name: :asc, first_name: :asc, last_name: :asc)
-        .map { |p| [p, p.id] }
+        .map { |p| [p.to_s, p.id] }
   end
 
   def referred_doctor_for_select
@@ -18,7 +18,7 @@ module ApplicationHelper
       ReferredDoctor
         .by_doctor(current_user.id)
         .order(full_name: :asc)
-        .map { |p| [p, p.id] }
+        .map { |p| [p.to_s, p.id] }
   end
 
   def states_for_select


### PR DESCRIPTION
When we were using [p, p.id] the p variable included the whole model
information, to return only the name, I'm using to_s because is defined
in the changed models
