### PR TITLE
Add combobox errors

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,6 +15,12 @@ module ApplicationHelper
       .map { |u| [u.to_s, u.id] }
   end
 
+  def combobox_error(object, field, type = :blank)
+    return unless object.errors.added?(field, type)
+
+    content_tag(:p, object.errors.full_messages_for(field).first, class: 'mt-2 text-sm text-red-600 dark:text-red-600')
+  end
+
   def referred_doctors_for_select
     @referred_doctors_for_select ||=
       current_hospital

--- a/app/views/appointments/_form.html.haml
+++ b/app/views/appointments/_form.html.haml
@@ -7,6 +7,7 @@
     .mb-4
       = f.label :patient, class: label_classes
       = f.combobox :patient_id, patients_for_select, default: params[:patient_id], data: { hw_combobox_fetch_information_value: true }
+      = combobox_error(f.object, :patient)
 
     = f.input :reason
 

--- a/app/views/hospitalizations/_form.html.haml
+++ b/app/views/hospitalizations/_form.html.haml
@@ -7,10 +7,12 @@
     .mb-4
       = f.label :patient, class: label_classes
       = f.combobox :patient_id, patients_for_select, default: params[:patient_id]
+      = combobox_error(f.object, :patient)
 
     .mb-4
       = f.label :referred_doctor, class: label_classes
       = f.combobox :referred_doctor_id, referred_doctors_for_select
+      = combobox_error(f.object, :referred_doctor)
 
     = f.input :status, collection: statuses_for_select, prompt: true
     = f.input :starting, as: :date, html5: true

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -12,6 +12,18 @@ RSpec.describe ApplicationHelper do
     expect(helper.blood_groups_for_select).to eq groups
   end
 
+  describe '#combobox_error' do
+    it 'shows the error' do
+      object = double('object', errors: double('errors', added?: true, full_messages_for: ['Error']))
+      expect(helper.combobox_error(object, :field)).to eq '<p class="mt-2 text-sm text-red-600 dark:text-red-600">Error</p>'
+    end
+
+    it 'does not show the error' do
+      object = double('object', errors: double('errors', added?: false, full_messages_for: ['Error']))
+      expect(helper.combobox_error(object, :field)).to eq nil
+    end
+  end
+
   context '#sidebar_classes' do
     it 'returns hover classes' do
       allow(helper).to receive(:controller_name).and_return(:controller_name)

--- a/spec/system/hospitalizations_spec.rb
+++ b/spec/system/hospitalizations_spec.rb
@@ -56,6 +56,8 @@ RSpec.describe "Hospitalization's flow", type: :system do
 
       expect(page).to have_current_path new_hospitalization_path
 
+      expect(page).to have_content 'Paciente no puede estar vacío'
+      expect(page).to have_content 'Destinatario no puede estar vacío'
       expect(page).to have_content 'Fecha de ingreso no puede estar en blanco'
       expect(page).to have_content 'Fecha de egreso no puede estar en blanco'
 


### PR DESCRIPTION
Right now it is not possible to see the combobox's errors, so, this is
adding the errors for that field
