### PR TITLE
Bump caniuse-lite package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -986,9 +986,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001647",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001647.tgz",
-      "integrity": "sha512-n83xdNiyeNcHpzWY+1aFbqCK7LuLfBricc4+alSQL2Xb6OR3XpnQAmlDG+pQcdTfiHRuLcQ96VOfrPSGiNJYSg==",
+      "version": "1.0.30001695",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001695.tgz",
+      "integrity": "sha512-vHyLade6wTgI2u1ec3WQBxv+2BrTERV28UXQu9LO6lZ9pYeMk34vjXFLOxo1A4UBA8XTL4njRQZdno/yYaSmWw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
At the rails logs I found a message suggesting to run the command `npx update-browserslist-db@latest`: which updated the caniuse-lite database.